### PR TITLE
Refactored keyboard deletion logic to handle grapheme clusters and te…

### DIFF
--- a/feature/keyboard/src/main/java/com/armandodarienzo/k9board/keyboard/KeyboardEffect.kt
+++ b/feature/keyboard/src/main/java/com/armandodarienzo/k9board/keyboard/KeyboardEffect.kt
@@ -11,4 +11,6 @@ sealed class KeyboardEffect : Reducer.SideEffect {
     data class PerformEditorAction(val actionId: Int) : KeyboardEffect()
     // Finish previous composing span then start a new one — used in manual mode when switching keys
     data class FinishComposingAndStart(val text: String) : KeyboardEffect()
+    data class FinishComposingAndDelete(val charsBefore: Int) : KeyboardEffect()
+    data object DeleteSelection : KeyboardEffect()
 }

--- a/feature/keyboard/src/main/java/com/armandodarienzo/k9board/keyboard/KeyboardReducer.kt
+++ b/feature/keyboard/src/main/java/com/armandodarienzo/k9board/keyboard/KeyboardReducer.kt
@@ -1,6 +1,5 @@
 package com.armandodarienzo.k9board.keyboard
 
-import android.view.KeyEvent
 import com.armandodarienzo.k9board.model.KeyboardCapsStatus
 import com.armandodarienzo.k9board.shared.ui.base.Reducer
 
@@ -111,8 +110,32 @@ class KeyboardReducer : Reducer<KeyboardState, KeyboardEvent, KeyboardEffect> {
                     }
                 else -> previousState.capsIndexes
             }
-            previousState.copy(capsIndexes = newCapsIndexes) to
-                KeyboardEffect.SendKeyEvent(KeyEvent.KEYCODE_DEL)
+
+            // Measure the full grapheme cluster so combined emoji (skin-tone, ZWJ, VS16…)
+            // are deleted whole rather than one code-point at a time.
+            val clusterLen = if (previousState.textSelectionText.isEmpty())
+                previousState.textBeforeCursor.lastGraphemeClusterLength()
+            else 0
+
+            val effect = if (previousState.textSelectionText.isNotEmpty())
+                KeyboardEffect.DeleteSelection
+            else
+                KeyboardEffect.FinishComposingAndDelete(clusterLen)
+
+            val newTextBefore = if (clusterLen > 0)
+                previousState.textBeforeCursor.dropLast(clusterLen)
+            else
+                previousState.textBeforeCursor
+
+            previousState.copy(
+                capsIndexes = newCapsIndexes,
+                textBeforeCursor = newTextBefore,
+                textSelectionStart = newTextBefore.length,
+                textSelectionEnd = newTextBefore.length,
+                textCompositionText = "",
+                textCompositionStart = newTextBefore.length,
+                textCompositionEnd = newTextBefore.length,
+            ) to effect
         }
 
         is KeyboardEvent.ComposingRegionReady -> {
@@ -209,4 +232,16 @@ class KeyboardReducer : Reducer<KeyboardState, KeyboardEvent, KeyboardEffect> {
             wordsMaxLength = event.wordsMaxLength,
         ) to null
     }
+}
+
+// Returns the UTF-16 length of the last Unicode grapheme cluster in the string.
+// Using BreakIterator ensures combined emoji (skin-tone modifiers, ZWJ sequences,
+// variation selectors, flag pairs) are treated as a single unit.
+private fun String.lastGraphemeClusterLength(): Int {
+    if (isEmpty()) return 0
+    val bi = java.text.BreakIterator.getCharacterInstance()
+    bi.setText(this)
+    val end = bi.last()
+    val start = bi.previous()
+    return if (start == java.text.BreakIterator.DONE) end else end - start
 }

--- a/feature/keyboard/src/main/java/com/armandodarienzo/k9board/keyboard/service/Key9Service.kt
+++ b/feature/keyboard/src/main/java/com/armandodarienzo/k9board/keyboard/service/Key9Service.kt
@@ -255,6 +255,14 @@ open class Key9Service : InputMethodService(), LifecycleOwner, ViewModelStoreOwn
                 currentInputConnection?.finishComposingText()
                 currentInputConnection?.setComposingText(effect.text, 1)
             }
+            is KeyboardEffect.FinishComposingAndDelete -> {
+                currentInputConnection?.finishComposingText()
+                if (effect.charsBefore > 0)
+                    currentInputConnection?.deleteSurroundingText(effect.charsBefore, 0)
+            }
+            KeyboardEffect.DeleteSelection -> {
+                currentInputConnection?.commitText("", 1)
+            }
         }
     }
 }

--- a/feature/keyboard/src/test/java/com/armandodarienzo/k9board/keyboard/KeyboardReducerDeleteTest.kt
+++ b/feature/keyboard/src/test/java/com/armandodarienzo/k9board/keyboard/KeyboardReducerDeleteTest.kt
@@ -1,0 +1,187 @@
+package com.armandodarienzo.k9board.keyboard
+
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class KeyboardReducerDeleteTest {
+
+    private lateinit var reducer: KeyboardReducer
+
+    @Before
+    fun setUp() {
+        reducer = KeyboardReducer()
+    }
+
+    // region no-selection deletes → FinishComposingAndDelete
+
+    @Test
+    fun `delete with no selection emits FinishComposingAndDelete with charsBefore 1`() {
+        val state = KeyboardState(textBeforeCursor = "Hello", textSelectionStart = 5)
+        val (newState, effect) = reducer.reduce(state, KeyboardEvent.DeleteKeyPressed)
+        assertEquals(KeyboardEffect.FinishComposingAndDelete(1), effect)
+        assertEquals("Hell", newState.textBeforeCursor)
+        assertEquals(4, newState.textSelectionStart)
+        assertEquals("", newState.textCompositionText)
+    }
+
+    @Test
+    fun `delete in manual mode with composing char emits FinishComposingAndDelete with charsBefore 1`() {
+        val state = KeyboardState(
+            isManual = true,
+            textBeforeCursor = "Hello x",
+            textSelectionStart = 7,
+            textCompositionText = "x",
+        )
+        val (newState, effect) = reducer.reduce(state, KeyboardEvent.DeleteKeyPressed)
+        assertEquals(KeyboardEffect.FinishComposingAndDelete(1), effect)
+        assertEquals("Hello ", newState.textBeforeCursor)
+        assertEquals(6, newState.textSelectionStart)
+        assertEquals("", newState.textCompositionText)
+    }
+
+    @Test
+    fun `delete when nothing before cursor emits FinishComposingAndDelete(0) and leaves caps unchanged`() {
+        val state = KeyboardState(
+            textBeforeCursor = "",
+            textSelectionStart = 0,
+            capsIndexes = listOf(2),
+        )
+        val (newState, effect) = reducer.reduce(state, KeyboardEvent.DeleteKeyPressed)
+        assertEquals(KeyboardEffect.FinishComposingAndDelete(0), effect)
+        assertEquals("", newState.textBeforeCursor)
+        assertEquals(0, newState.textSelectionStart)
+        assertEquals(listOf(2), newState.capsIndexes)
+    }
+
+    // region caps-index tracking
+
+    @Test
+    fun `delete removes the cap index of the deleted char`() {
+        // "He" — 'H' is capped at 0, cursor at 2, deleting 'e' at position 1
+        val state = KeyboardState(
+            textBeforeCursor = "He",
+            textSelectionStart = 2,
+            capsIndexes = listOf(0, 1),
+        )
+        val (newState, effect) = reducer.reduce(state, KeyboardEvent.DeleteKeyPressed)
+        assertEquals(KeyboardEffect.FinishComposingAndDelete(1), effect)
+        assertEquals(listOf(0), newState.capsIndexes)
+        assertEquals("H", newState.textBeforeCursor)
+        assertEquals(1, newState.textSelectionStart)
+    }
+
+    // region selection deletes → DeleteSelection
+
+    @Test
+    fun `delete with selection removes only cap indexes inside the selection`() {
+        // "Hello" — 'H'=0 capped, 'l'=3 capped; selection covers [3,5) ("lo")
+        val state = KeyboardState(
+            textBeforeCursor = "Hel",
+            textSelectionStart = 3,
+            textSelectionEnd = 5,
+            textSelectionText = "Lo",
+            capsIndexes = listOf(0, 3),
+        )
+        val (newState, effect) = reducer.reduce(state, KeyboardEvent.DeleteKeyPressed)
+        assertEquals(KeyboardEffect.DeleteSelection, effect)
+        assertEquals(listOf(0), newState.capsIndexes)
+        assertEquals("Hel", newState.textBeforeCursor)
+        assertEquals(3, newState.textSelectionStart)
+    }
+
+    // region emoji
+
+    @Test
+    fun `delete emoji length 2 (surrogate pair) deletes entire cluster`() {
+        // 😀 is a surrogate pair: 2 UTF-16 chars (length == 2)
+        val emoji = "😀"
+        assertEquals(2, emoji.length)
+        val state = KeyboardState(
+            textBeforeCursor = emoji,
+            textSelectionStart = emoji.length,
+            textSelectionEnd = emoji.length,
+            textSelectionText = "",
+        )
+        val (newState, effect) = reducer.reduce(state, KeyboardEvent.DeleteKeyPressed)
+        assertEquals(KeyboardEffect.FinishComposingAndDelete(2), effect)
+        assertEquals("", newState.textBeforeCursor)
+        assertEquals(0, newState.textSelectionStart)
+        assertEquals("", newState.textCompositionText)
+    }
+
+    // Length 3: surrogate pair (👁 U+1F441) + variation selector-16 (U+FE0F).
+    // BreakIterator treats the whole sequence as one grapheme cluster → deleted whole.
+    @Test
+    fun `delete emoji length 3 (surrogate pair + variation selector) deletes entire cluster`() {
+        val emoji = "👁️" // U+1F441 + U+FE0F — eye with VS16, length = 3
+        assertEquals(3, emoji.length)
+        val state = KeyboardState(
+            textBeforeCursor = emoji,
+            textSelectionStart = emoji.length,
+            textSelectionEnd = emoji.length,
+            textSelectionText = "",
+        )
+        val (newState, effect) = reducer.reduce(state, KeyboardEvent.DeleteKeyPressed)
+        assertEquals(KeyboardEffect.FinishComposingAndDelete(3), effect)
+        assertEquals("", newState.textBeforeCursor)
+        assertEquals(0, newState.textSelectionStart)
+        assertEquals("", newState.textCompositionText)
+    }
+
+    // Length 4: two surrogate pairs — base emoji + skin-tone modifier.
+    // BreakIterator treats base + modifier as one grapheme cluster → deleted whole.
+    @Test
+    fun `delete emoji length 4 (surrogate pair + modifier surrogate pair) deletes entire cluster`() {
+        val emoji = "👍🏽" // U+1F44D + U+1F3FD — thumbs-up medium skin tone, length = 4
+        assertEquals(4, emoji.length)
+        val state = KeyboardState(
+            textBeforeCursor = emoji,
+            textSelectionStart = emoji.length,
+            textSelectionEnd = emoji.length,
+            textSelectionText = "",
+        )
+        val (newState, effect) = reducer.reduce(state, KeyboardEvent.DeleteKeyPressed)
+        assertEquals(KeyboardEffect.FinishComposingAndDelete(4), effect)
+        assertEquals("", newState.textBeforeCursor)
+        assertEquals(0, newState.textSelectionStart)
+        assertEquals("", newState.textCompositionText)
+    }
+
+    // Length 5: ZWJ sequence — surrogate pair + ZWJ + surrogate pair.
+    // BreakIterator treats the whole ZWJ sequence as one grapheme cluster → deleted whole.
+    @Test
+    fun `delete ZWJ emoji length 5 deletes entire cluster`() {
+        val emoji = "👨‍💻" // U+1F468 + ZWJ + U+1F4BB — man technologist, length = 5
+        assertEquals(5, emoji.length)
+        val state = KeyboardState(
+            textBeforeCursor = emoji,
+            textSelectionStart = emoji.length,
+            textSelectionEnd = emoji.length,
+            textSelectionText = "",
+        )
+        val (newState, effect) = reducer.reduce(state, KeyboardEvent.DeleteKeyPressed)
+        assertEquals(KeyboardEffect.FinishComposingAndDelete(5), effect)
+        assertEquals("", newState.textBeforeCursor)
+        assertEquals(0, newState.textSelectionStart)
+        assertEquals("", newState.textCompositionText)
+    }
+
+    @Test
+    fun `delete selected emoji emits DeleteSelection`() {
+        val emoji = "😀"
+        val state = KeyboardState(
+            textBeforeCursor = "Hi ",
+            textSelectionStart = 3,
+            textSelectionEnd = 3 + emoji.length,
+            textSelectionText = emoji,
+            capsIndexes = listOf(0), // 'H' capped, outside selection
+        )
+        val (newState, effect) = reducer.reduce(state, KeyboardEvent.DeleteKeyPressed)
+        assertEquals(KeyboardEffect.DeleteSelection, effect)
+        assertEquals(listOf(0), newState.capsIndexes) // unaffected: 0 not in [3, 5)
+        assertEquals("Hi ", newState.textBeforeCursor)
+        assertEquals(3, newState.textSelectionStart)
+        assertEquals("", newState.textCompositionText)
+    }
+}


### PR DESCRIPTION
…xt selections accurately.

- Added `FinishComposingAndDelete` and `DeleteSelection` keyboard effects.
- Updated `KeyboardReducer` to calculate the length of the last grapheme cluster using `BreakIterator`, ensuring complex emojis (ZWJ sequences, modifiers) are deleted as single units.
- Implemented corresponding handlers in `Key9Service` using `deleteSurroundingText` and `commitText`.
- Added comprehensive unit tests in `KeyboardReducerDeleteTest` covering single characters, selections, and various emoji types.